### PR TITLE
Document worker-process websocket init and dedicated-host transport guidance

### DIFF
--- a/docs/plugins/websockets/config.mdx
+++ b/docs/plugins/websockets/config.mdx
@@ -76,6 +76,10 @@ export default async function initializePsychicApp(opts: PsychicAppInitOptions =
 }
 ```
 
+:::info Run in every process that calls `Ws.emit()`
+`PsychicAppWebsockets.init()` must run in **every** process that calls `Ws.emit()` — including background worker processes, not just the dedicated websocket server. Each Node process has its own module cache and does not share the websocket app instance with other processes. If a worker process skips this call, the first `Ws.emit()` in that process will throw a `cachePsychicAppWebsockets` error. Guard the initializer by service role so it runs for both `'websockets'` and `'worker'` roles.
+:::
+
 4. We recommend you include a singleton within your application to simplify your websockets integration:
 
 ```ts
@@ -161,3 +165,26 @@ export default (wsApp: PsychicAppWebsockets) => {
   })
 }
 ```
+
+## Dedicated WebSocket Host
+
+In production it is common to run the websocket server as a separate process or host. Socket.IO clients default to starting with long-polling before upgrading to a native WebSocket connection. When the websocket server runs as a dedicated host, polling requests can conflict with its HTTP handler, producing header-sent failures or stale browser state: background jobs complete and events are published, but the browser never receives live updates until manual refresh.
+
+**Diagnostic signals:**
+
+- Browser network tab shows `transport=polling` requests to the websocket host.
+- Websocket server logs show HTTP or header errors even though jobs complete successfully.
+
+For dedicated websocket hosts, configure the Socket.IO client to use native WebSocket transport only:
+
+```ts
+import { io } from 'socket.io-client'
+
+const socket = io(websocketHost, {
+  path: '/ws',
+  transports: ['websocket'],
+  auth: { token },
+})
+```
+
+Do not include `'polling'` unless you have explicitly verified that long-polling works end-to-end through your proxy and websocket route stack. This failure is easy to misdiagnose as a queue, worker, or subscription bug — check the client transport first.

--- a/docs/plugins/websockets/config.mdx
+++ b/docs/plugins/websockets/config.mdx
@@ -76,15 +76,14 @@ export default async function initializePsychicApp(opts: PsychicAppInitOptions =
 }
 ```
 
-:::info Run in every process that calls `Ws.emit()`
-`PsychicAppWebsockets.init()` must run in **every** process that calls `Ws.emit()` — not just the dedicated websocket server. Each Node process has its own module cache and does not share the websocket app instance with other processes.
+:::info Initializes in all processes by default
+`PsychicAppWebsockets.init()` runs in all processes by default. Any process — websocket server, web server, or worker — may call `Ws.emit()`, and skipping init in any of them causes a runtime `cachePsychicAppWebsockets` error that is easy to misdiagnose. Each Node process has its own module cache and does not share the websocket app instance with other processes.
 
-All three named service roles need it:
-- **`websockets`** — owns `Cable.start()` and socket connection handling
-- **`web`** — controllers may call `Ws.emit()` directly in response to HTTP requests
-- **`worker`** — background jobs may call `Ws.emit()` to push real-time notifications
+To restrict which roles can push messages, add a guard in `conf/initializers/websockets.ts`:
 
-Only `'unknown'` processes (migrations, CLI, REPL) should skip it. If any of the above processes skips this call, the first `Ws.emit()` in that process will throw a `cachePsychicAppWebsockets` error.
+```ts
+if (!['websockets', 'web', 'worker'].includes(AppEnv.serviceRole) && !AppEnv.isTest) return
+```
 :::
 
 4. We recommend you include a singleton within your application to simplify your websockets integration:

--- a/docs/plugins/websockets/config.mdx
+++ b/docs/plugins/websockets/config.mdx
@@ -172,16 +172,9 @@ export default (wsApp: PsychicAppWebsockets) => {
 }
 ```
 
-## Dedicated WebSocket Host
+## Client Transport
 
-In production it is common to run the websocket server as a separate process or host. Socket.IO clients default to starting with long-polling before upgrading to a native WebSocket connection. When the websocket server runs as a dedicated host, polling requests can conflict with its HTTP handler, producing header-sent failures or stale browser state: background jobs complete and events are published, but the browser never receives live updates until manual refresh.
-
-**Diagnostic signals:**
-
-- Browser network tab shows `transport=polling` requests to the websocket host.
-- Websocket server logs show HTTP or header errors even though jobs complete successfully.
-
-For dedicated websocket hosts, configure the Socket.IO client to use native WebSocket transport only:
+Always set `transports: ['websocket']` on the Socket.IO client. Socket.IO defaults to long-polling first for historical reasons — that fallback is unnecessary today since WebSocket is universally supported by modern browsers and mobile apps. Skipping the polling phase means faster connection establishment and eliminates a class of subtle failures where polling requests interfere with the websocket server's HTTP handler.
 
 ```ts
 import { io } from 'socket.io-client'
@@ -191,5 +184,3 @@ const socket = io(websocketHost, {
   auth: { token },
 })
 ```
-
-Do not include `'polling'` unless you have explicitly verified that long-polling works end-to-end through your proxy and websocket route stack. This failure is easy to misdiagnose as a queue, worker, or subscription bug — check the client transport first.

--- a/docs/plugins/websockets/config.mdx
+++ b/docs/plugins/websockets/config.mdx
@@ -187,7 +187,6 @@ For dedicated websocket hosts, configure the Socket.IO client to use native WebS
 import { io } from 'socket.io-client'
 
 const socket = io(websocketHost, {
-  path: '/ws',
   transports: ['websocket'],
   auth: { token },
 })

--- a/docs/plugins/websockets/config.mdx
+++ b/docs/plugins/websockets/config.mdx
@@ -77,7 +77,14 @@ export default async function initializePsychicApp(opts: PsychicAppInitOptions =
 ```
 
 :::info Run in every process that calls `Ws.emit()`
-`PsychicAppWebsockets.init()` must run in **every** process that calls `Ws.emit()` — including background worker processes, not just the dedicated websocket server. Each Node process has its own module cache and does not share the websocket app instance with other processes. If a worker process skips this call, the first `Ws.emit()` in that process will throw a `cachePsychicAppWebsockets` error. Guard the initializer by service role so it runs for both `'websockets'` and `'worker'` roles.
+`PsychicAppWebsockets.init()` must run in **every** process that calls `Ws.emit()` — not just the dedicated websocket server. Each Node process has its own module cache and does not share the websocket app instance with other processes.
+
+All three named service roles need it:
+- **`websockets`** — owns `Cable.start()` and socket connection handling
+- **`web`** — controllers may call `Ws.emit()` directly in response to HTTP requests
+- **`worker`** — background jobs may call `Ws.emit()` to push real-time notifications
+
+Only `'unknown'` processes (migrations, CLI, REPL) should skip it. If any of the above processes skips this call, the first `Ws.emit()` in that process will throw a `cachePsychicAppWebsockets` error.
 :::
 
 4. We recommend you include a singleton within your application to simplify your websockets integration:

--- a/docs/plugins/websockets/emitting.mdx
+++ b/docs/plugins/websockets/emitting.mdx
@@ -9,6 +9,16 @@ ai_summary: "Emit to registered users from anywhere in application (including ba
 
 Once you have successfully built a registration flow for your users (see the [Registering guides](./registering) if you have not), you are able to emit to those registered users anywhere in your application (yes, including within background jobs!).
 
+:::warning Worker processes must initialize `PsychicAppWebsockets`
+`Ws.emit()` boots a `PsychicAppWebsockets` instance on its first call. If a background worker process skipped the websocket initializer (because the guard was limited to `serviceRole === 'websockets'`), the call throws:
+
+```
+must call `cachePsychicAppWebsockets` before loading cached psychic application websockets
+```
+
+Each Node process has its own module cache — the websocket app instance is **not** shared between the websocket server process and worker processes. To fix this, include `'worker'` in the initializer guard alongside `'websockets'`. The dedicated websocket server still owns socket connection handling; the worker only needs enough initialization for the Redis connection that `Ws.emit()` uses. See [Config](./config) for the recommended initializer pattern.
+:::
+
 To establish a new Ws instance, we need to provide it with a set of routes that the application allows, like so:
 
 ```ts

--- a/docs/plugins/websockets/emitting.mdx
+++ b/docs/plugins/websockets/emitting.mdx
@@ -9,14 +9,14 @@ ai_summary: "Emit to registered users from anywhere in application (including ba
 
 Once you have successfully built a registration flow for your users (see the [Registering guides](./registering) if you have not), you are able to emit to those registered users anywhere in your application (yes, including within background jobs!).
 
-:::warning Worker processes must initialize `PsychicAppWebsockets`
-`Ws.emit()` boots a `PsychicAppWebsockets` instance on its first call. If a background worker process skipped the websocket initializer (because the guard was limited to `serviceRole === 'websockets'`), the call throws:
+:::warning Each process must initialize `PsychicAppWebsockets`
+`Ws.emit()` boots a `PsychicAppWebsockets` instance on its first call. Each Node process has its own module cache — the websocket app instance is **not** shared across processes. If any process skips `PsychicAppWebsockets.init()` (e.g. via a service-role guard that is too narrow), the call throws:
 
 ```
 must call `cachePsychicAppWebsockets` before loading cached psychic application websockets
 ```
 
-Each Node process has its own module cache — the websocket app instance is **not** shared across processes. By default `PsychicAppWebsockets.init()` runs in all processes so any process can safely call `Ws.emit()`. See [Config](./config) for details and the optional role guard.
+By default the generated initializer runs in all processes. See [Config](./config) for details and the optional role guard.
 :::
 
 To establish a new Ws instance, we need to provide it with a set of routes that the application allows, like so:

--- a/docs/plugins/websockets/emitting.mdx
+++ b/docs/plugins/websockets/emitting.mdx
@@ -16,7 +16,7 @@ Once you have successfully built a registration flow for your users (see the [Re
 must call `cachePsychicAppWebsockets` before loading cached psychic application websockets
 ```
 
-Each Node process has its own module cache — the websocket app instance is **not** shared between the websocket server process and worker processes. To fix this, include `'worker'` in the initializer guard alongside `'websockets'`. The dedicated websocket server still owns socket connection handling; the worker only needs enough initialization for the Redis connection that `Ws.emit()` uses. See [Config](./config) for the recommended initializer pattern.
+Each Node process has its own module cache — the websocket app instance is **not** shared across processes. All three named service roles (`'websockets'`, `'web'`, `'worker'`) need `PsychicAppWebsockets.init()` to run; only `'unknown'` processes (migrations, CLI, REPL) should skip it. See [Config](./config) for the recommended initializer pattern.
 :::
 
 To establish a new Ws instance, we need to provide it with a set of routes that the application allows, like so:

--- a/docs/plugins/websockets/emitting.mdx
+++ b/docs/plugins/websockets/emitting.mdx
@@ -16,7 +16,7 @@ Once you have successfully built a registration flow for your users (see the [Re
 must call `cachePsychicAppWebsockets` before loading cached psychic application websockets
 ```
 
-Each Node process has its own module cache — the websocket app instance is **not** shared across processes. All three named service roles (`'websockets'`, `'web'`, `'worker'`) need `PsychicAppWebsockets.init()` to run; only `'unknown'` processes (migrations, CLI, REPL) should skip it. See [Config](./config) for the recommended initializer pattern.
+Each Node process has its own module cache — the websocket app instance is **not** shared across processes. By default `PsychicAppWebsockets.init()` runs in all processes so any process can safely call `Ws.emit()`. See [Config](./config) for details and the optional role guard.
 :::
 
 To establish a new Ws instance, we need to provide it with a set of routes that the application allows, like so:


### PR DESCRIPTION
## Summary

- **Worker-process initialization requirement** (`emitting.mdx`, `config.mdx`): `Ws.emit()` calls `PsychicAppWebsockets.getOrFail()` on first use; if the worker process skipped the initializer (guard limited to `serviceRole === 'websockets'`), it throws a `cachePsychicAppWebsockets` error and BullMQ retries the job. Added a warning in `emitting.mdx` and an info callout in `config.mdx` documenting the per-process module-cache isolation and the fix (include `'worker'` in the initializer guard).
- **Dedicated WebSocket Host transport** (`config.mdx`): Socket.IO defaults to long-polling before upgrading to native WebSocket. In dedicated-WS-host topologies this causes polling requests to collide with the websocket server's HTTP handler — browser appears stale until refresh, server logs show header errors. New "Dedicated WebSocket Host" section documents the two diagnostic signals and the `transports: ['websocket']` client fix.

## Test plan

- [ ] Review `emitting.mdx` warning block renders correctly in Docusaurus
- [ ] Review `config.mdx` info callout and new "Dedicated WebSocket Host" section render correctly
- [ ] Verify no broken links or anchor references

🤖 Generated with [Claude Code](https://claude.com/claude-code)