### PR TITLE
docs: link BullMQ connection defaults to sources; fix ws-adapter maxRetriesPerRequest

### DIFF
--- a/docs/plugins/websockets/config.mdx
+++ b/docs/plugins/websockets/config.mdx
@@ -51,7 +51,8 @@ function initializeWebsockets(wsApp: PsychicAppWebsockets) {
             username: AppEnv.string('WS_REDIS_USERNAME'),
             password: AppEnv.string('WS_REDIS_PASSWORD'),
             tls: {},
-            maxRetriesPerRequest: null,
+            maxRetriesPerRequest: 3,
+            commandTimeout: 10000,
           })
         : new Redis({
             host: AppEnv.string('WS_REDIS_HOST', { optional: true }) || 'localhost',
@@ -59,7 +60,8 @@ function initializeWebsockets(wsApp: PsychicAppWebsockets) {
             username: AppEnv.string('WS_REDIS_USERNAME', { optional: true }),
             password: AppEnv.string('WS_REDIS_PASSWORD', { optional: true }),
             // tls:  {},
-            maxRetriesPerRequest: null,
+            maxRetriesPerRequest: 3,
+            commandTimeout: 10000,
           }),
     )
   }
@@ -148,7 +150,8 @@ if (!AppEnv.isTest) {
           username: AppEnv.string('WS_REDIS_USERNAME'),
           password: AppEnv.string('WS_REDIS_PASSWORD'),
           tls: {},
-          maxRetriesPerRequest: null,
+          maxRetriesPerRequest: 3,
+          commandTimeout: 10000,
         })
       : new Redis({
           host: AppEnv.string('WS_REDIS_HOST', { optional: true }) || 'localhost',
@@ -156,11 +159,16 @@ if (!AppEnv.isTest) {
           username: AppEnv.string('WS_REDIS_USERNAME', { optional: true }),
           password: AppEnv.string('WS_REDIS_PASSWORD', { optional: true }),
           // tls: {},
-          maxRetriesPerRequest: null,
+          maxRetriesPerRequest: 3,
+          commandTimeout: 10000,
         }),
   )
 }
 ```
+
+:::note Bound the connection — do not set `maxRetriesPerRequest: null`
+Unlike a BullMQ worker connection (which _must_ use `maxRetriesPerRequest: null` for its blocking `BLPOP`/`BRPOPLPUSH` commands), the socket.io redis-adapter issues no blocking commands. Setting `null` here makes a broadcast or socket-registry lookup hang indefinitely when Redis is unreachable — including a `Ws.emit()` from a worker, which stalls that job. Bound `maxRetriesPerRequest` and set a `commandTimeout` so the connection fails fast instead. The adapter needs no special connection options — see the [socket.io Redis adapter docs](https://socket.io/docs/v4/redis-adapter/); for the contrasting worker requirement see [BullMQ connections](https://docs.bullmq.io/guide/connections).
+:::
 
 ### Connection limits
 

--- a/docs/plugins/workers/config.mdx
+++ b/docs/plugins/workers/config.mdx
@@ -99,7 +99,11 @@ export default (workersApp: PsychicAppWorkers) => {
       },
     },
 
-    // Any instance can push onto the queue
+    // Any instance can push onto the queue. This producer (non-blocking) connection
+    // sets `enableOfflineQueue: false` so `queue.add()` fails fast when Redis is down
+    // instead of buffering jobs in memory that vanish on restart. BullMQ recommends
+    // disabling the offline queue on the Queue while leaving it on for Workers.
+    // https://docs.bullmq.io/patterns/failing-fast-when-redis-is-down
     defaultQueueConnection: AppEnv.isProduction
       ? new Cluster(
           [
@@ -130,7 +134,12 @@ export default (workersApp: PsychicAppWorkers) => {
           enableOfflineQueue: false,
         }),
 
-    // Only establish the worker Redis connection if on an instance that does the work
+    // Only establish the worker Redis connection if on an instance that does the work.
+    // This consumer (blocking) connection sets `maxRetriesPerRequest: null` — required by
+    // BullMQ, whose Worker/QueueEvents use blocking commands (BLPOP/BRPOPLPUSH) on a
+    // duplicated connection and throw unless it is null. Do not change it, and do NOT copy
+    // `null` to non-blocking connections (the queue above, the websockets adapter), which
+    // should fail fast. https://docs.bullmq.io/guide/connections
     defaultWorkerConnection: !AppEnv.boolean('WORKER_SERVICE')
       ? undefined
       : AppEnv.isProduction

--- a/docs/plugins/workers/installation.mdx
+++ b/docs/plugins/workers/installation.mdx
@@ -72,7 +72,11 @@ export default (workersApp: PsychicAppWorkers) => {
       },
     },
 
-    // Any instance can push onto the queue
+    // Any instance can push onto the queue. This producer (non-blocking) connection
+    // sets `enableOfflineQueue: false` so `queue.add()` fails fast when Redis is down
+    // instead of buffering jobs in memory that vanish on restart. BullMQ recommends
+    // disabling the offline queue on the Queue while leaving it on for Workers.
+    // https://docs.bullmq.io/patterns/failing-fast-when-redis-is-down
     defaultQueueConnection: AppEnv.isProduction
       ? new Cluster(
           [
@@ -103,7 +107,12 @@ export default (workersApp: PsychicAppWorkers) => {
           enableOfflineQueue: false,
         }),
 
-    // Only establish the worker Redis connection if on an instance that does the work
+    // Only establish the worker Redis connection if on an instance that does the work.
+    // This consumer (blocking) connection sets `maxRetriesPerRequest: null` — required by
+    // BullMQ, whose Worker/QueueEvents use blocking commands (BLPOP/BRPOPLPUSH) on a
+    // duplicated connection and throw unless it is null. Do not change it, and do NOT copy
+    // `null` to non-blocking connections (the queue above, the websockets adapter), which
+    // should fail fast. https://docs.bullmq.io/guide/connections
     defaultWorkerConnection: !AppEnv.boolean('WORKER_SERVICE')
       ? undefined
       : AppEnv.isProduction

--- a/docs/security/workers-and-redis.mdx
+++ b/docs/security/workers-and-redis.mdx
@@ -156,8 +156,8 @@ This is a recipe, not a framework primitive. If your app needs it, write the few
 
 The `create-psychic` workers boilerplate already sets the production-correct values for the easy-to-get-wrong knobs. Worth knowing they are there:
 
-- **`enableOfflineQueue: false`** on the queue connection — when Redis is unreachable, `queue.add()` fails fast instead of buffering jobs in process memory that vanish on restart. Surfaces outages immediately.
-- **`maxRetriesPerRequest: null`** on the worker connection — required by BullMQ for blocking commands (`BLPOP`, `BRPOPLPUSH`). The boilerplate sets it for you; do not change it.
+- **`enableOfflineQueue: false`** on the queue connection — when Redis is unreachable, `queue.add()` fails fast instead of buffering jobs in process memory that vanish on restart. Surfaces outages immediately. Source: [BullMQ — failing fast when Redis is down](https://docs.bullmq.io/patterns/failing-fast-when-redis-is-down) ("disable this queue for the Queue instance, but leave it as is for Worker instances").
+- **`maxRetriesPerRequest: null`** on the worker connection — required by BullMQ for blocking commands (`BLPOP`, `BRPOPLPUSH`); it throws otherwise. The boilerplate sets it for you; do not change it — and do **not** copy `null` onto non-blocking connections (the queue connection above, or the websockets adapter connection), which issue no blocking commands and should fail fast instead. Source: [BullMQ — connections](https://docs.bullmq.io/guide/connections).
 - **Cluster `dnsLookup: (address, callback) => callback(null, address)`** — required for AWS ElastiCache cluster mode where node IPs are returned in `CLUSTER SLOTS` and ioredis must not re-resolve them. The boilerplate sets it for you when you opt into Cluster.
 - **`clusterRetryStrategy` / `retryStrategy`** — bounded exponential backoff on connection retries (1s floor, 20s ceiling). Tunable but rarely needs to change.
 


### PR DESCRIPTION
## Why

Two related gaps in the Redis-connection guidance:

1. **The worker and queue connections have *different* BullMQ-mandated defaults, and neither was linked to a source** — so a reader can't tell requirement from folklore:
   - Queue (producer): `enableOfflineQueue: false` → [BullMQ — failing fast when Redis is down](https://docs.bullmq.io/patterns/failing-fast-when-redis-is-down) ("disable this queue for the Queue instance, but leave it as is for Worker instances").
   - Worker (consumer): `maxRetriesPerRequest: null` → [BullMQ — connections](https://docs.bullmq.io/guide/connections) (BullMQ throws if a blocking connection isn't `null`).

2. **The websockets adapter examples had copied the worker's `maxRetriesPerRequest: null`** — but the socket.io redis-adapter issues no blocking commands, so `null` makes an unreachable Redis hang broadcasts and socket-registry lookups forever, including a worker `Ws.emit()` (which stalls that job). This actually happened in production. Bounded it (`maxRetriesPerRequest: 3` + `commandTimeout: 10000`) with a note explaining why it differs from the worker connection.

## Changes
- `security/workers-and-redis.mdx` — the two BullMQ source links + a "don't copy `null` to non-blocking connections" warning.
- `plugins/workers/{config,installation}.mdx` — same source links inline in the queue/worker connection comments.
- `plugins/websockets/config.mdx` — corrected all four ws-connection examples + a `:::note` on why it must fail fast.

Companion changes: create-psychic boilerplate (PR #230) and psychic-websockets error text (PR #64) carry the matching code fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)